### PR TITLE
fix build warning about using --loader flag on node

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
     "build:dev": "NODE_ENV=development npm install && tsoa spec-and-routes && tsc",
     "build:prod": "NODE_ENV=production npm install && tsoa spec-and-routes && tsc",
     "start-tesseract": "OCR_TRANSLATORS=tesseract node --loader ts-node/esm src/main.ts",
-    "start": "node --loader ts-node/esm src/main.ts",
-    "debug": "LOG_LEVEL=debug node --loader ts-node/esm src/main.ts",
+    "start": "node --import=./src/register.js src/main.ts",
+    "debug": "LOG_LEVEL=debug node --import=./src/register.js src/main.ts",
+    "debug-inspect": "LOG_LEVEL=debug node --import=./src/register.js src/main.ts --inspect-brk",
+    "debug-inspect-brk": "LOG_LEVEL=debug node --import=./src/register.js --inspect src/main.ts",
     "test": "echo \"No tests currently\" && exit 0"
   },
   "files": [

--- a/src/register.js
+++ b/src/register.js
@@ -1,0 +1,4 @@
+import { register } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+register('ts-node/esm', pathToFileURL('./'));


### PR DESCRIPTION
When I was building fin-ocr-rest, I noticed the warning:

```
(node:6969) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:
--import 'data:text/javascript,import { register } from "node:module"; import { pathToFileURL } from "node:url"; register("ts-node/esm", pathToFileURL("./"));'
```

I followed that warning to: https://github.com/nodejs/node/issues/51196 where it was discussed that the `--experimental-loader` flag (which has the alias `--loader`) could be going away at some point.  Rather than doing the suggested import of a whole script, I opted to follow the comments in the issue and move that script to a file that would then be imported by node.

Looks like this is all a part of using ts-node with ESM.